### PR TITLE
feat: Configure Docker to use Jib for building and pushing the backen…

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,9 +18,12 @@ services:
       retries: 10
 
   springboot:
-    build:
-      context: .
-      dockerfile: Dockerfile
+    # Use image from Docker Hub (built with Jib)
+    image: yaquod/yaquod-backend:latest
+    # Alternatively, uncomment below to build locally with Dockerfile
+    # build:
+    #   context: .
+    #   dockerfile: Dockerfile
     container_name: springboot-app
     depends_on:
       postgis:

--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,8 @@
     <properties>
         <java.version>21</java.version>
         <jjwt.version>0.11.5</jjwt.version>
+        <!-- Replace with your Docker Hub username -->
+        <docker.hub.username>yaquod</docker.hub.username>
     </properties>
     <dependencies>
         <dependency>
@@ -120,11 +122,6 @@
             <artifactId>spring-boot-starter-validation</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.h2database</groupId>
-            <artifactId>h2</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.orbisgis</groupId>
             <artifactId>h2gis</artifactId>
             <version>2.2.0</version>
@@ -144,6 +141,32 @@
     </dependencies>
     <build>
         <plugins>
+            <plugin>
+                <groupId>com.google.cloud.tools</groupId>
+                <artifactId>jib-maven-plugin</artifactId>
+                <version>3.5.1</version>
+                <configuration>
+                    <from>
+                        <image>eclipse-temurin:21-jre</image>
+                    </from>
+                    <to>
+                        <!-- Replace 'your-dockerhub-username' with your actual Docker Hub username -->
+                        <image>docker.io/${docker.hub.username}/yaquod-backend:${project.version}</image>
+                        <tags>
+                            <tag>latest</tag>
+                        </tags>
+                    </to>
+                    <container>
+                        <ports>
+                            <port>8000</port>
+                        </ports>
+                        <jvmFlags>
+                            <jvmFlag>-Djava.security.egd=file:/dev/./urandom</jvmFlag>
+                        </jvmFlags>
+                        <creationTime>USE_CURRENT_TIMESTAMP</creationTime>
+                    </container>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>


### PR DESCRIPTION
This pull request updates the backend build and deployment process to use the Jib Maven plugin for building Docker images and pushes them to Docker Hub, instead of building locally with a Dockerfile. It also removes the direct dependency on the H2 database for testing and introduces configuration improvements for containerization.

**Containerization and Deployment Improvements:**

* Updated `docker-compose.yml` to use a prebuilt Docker image (`yaquod/yaquod-backend:latest`) from Docker Hub for the `springboot` service, with an option to revert to local builds if needed.
* Added the Jib Maven plugin configuration in `pom.xml` to automate building and pushing Docker images to Docker Hub, using the `eclipse-temurin:21-jre` base image and exposing port 8000.
* Introduced a `docker.hub.username` property in `pom.xml` for easier configuration of the Docker Hub repository.

**Dependency Management:**

* Removed the `com.h2database:h2` test dependency from `pom.xml`, possibly to avoid conflicts or because it is no longer needed.