### PR TITLE
feature/order-start-end-trip

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,4 @@ build/
 /.agents
 /.github/skills
 /.windsurf
+nul

--- a/src/main/java/com/yaquodorg/yaquod/controller/TripController.java
+++ b/src/main/java/com/yaquodorg/yaquod/controller/TripController.java
@@ -39,8 +39,9 @@ public class TripController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "Failed to create trip request")
     })
     @PostMapping("/request")
+    @PreAuthorize("hasRole('CLIENT')")
     public ResponseEntity<ApiResponse<Request>> createRequest(@RequestBody TripRequestDto tripRequestDto,
-            @AuthenticationPrincipal User user) {
+                                                              @AuthenticationPrincipal User user) {
         try {
             Request request = requestService.createRequest(user.getId(),
                     tripRequestDto.getStartLong(),

--- a/src/main/java/com/yaquodorg/yaquod/controller/TripController.java
+++ b/src/main/java/com/yaquodorg/yaquod/controller/TripController.java
@@ -264,4 +264,26 @@ public class TripController {
                     .body(ApiResponse.createFailureResponse("Failed to start trip: " + e.getMessage()));
         }
     }
+
+    @Operation(summary = "End a trip", description = "Ends a trip and updates vehicle status. Requires CLIENT role.")
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Trip ended successfully"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "Failed to end trip"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Access denied - requires CLIENT role")
+    })
+    @PreAuthorize("hasRole('CLIENT')")
+    @PostMapping("/request/{requestId}/end")
+    public ResponseEntity<ApiResponse<MessageResponse>> endTrip(
+            @Parameter(description = "The unique ID of the request assigned with trip", required = true) @PathVariable Long requestId,
+            @Parameter(description = "Bearer authorization token", required = true) @RequestHeader("Authorization") String token) {
+        try {
+            tripService.endTrip(requestId);
+            return ResponseEntity
+                    .ok(ApiResponse.createSuccessResponse(new MessageResponse("Trip ended successfully!")));
+        } catch (Exception e) {
+            return ResponseEntity.badRequest()
+                    .body(ApiResponse.createFailureResponse("Failed to end trip: " + e.getMessage()));
+        }
+    }
+
 }

--- a/src/main/java/com/yaquodorg/yaquod/controller/TripController.java
+++ b/src/main/java/com/yaquodorg/yaquod/controller/TripController.java
@@ -41,7 +41,7 @@ public class TripController {
     @PostMapping("/request")
     @PreAuthorize("hasRole('CLIENT')")
     public ResponseEntity<ApiResponse<Request>> createRequest(@RequestBody TripRequestDto tripRequestDto,
-                                                              @AuthenticationPrincipal User user) {
+            @AuthenticationPrincipal User user) {
         try {
             Request request = requestService.createRequest(user.getId(),
                     tripRequestDto.getStartLong(),
@@ -254,8 +254,7 @@ public class TripController {
     @PreAuthorize("hasRole('CLIENT')")
     @PostMapping("/request/{requestId}/start")
     public ResponseEntity<ApiResponse<MessageResponse>> startTrip(
-            @Parameter(description = "The unique ID of the request assigned with trip", required = true) @PathVariable Long requestId,
-            @Parameter(description = "Bearer authorization token", required = true) @RequestHeader("Authorization") String token) {
+            @Parameter(description = "The unique ID of the request assigned with trip", required = true) @PathVariable Long requestId) {
         try {
             tripService.startTrip(requestId);
             return ResponseEntity
@@ -275,8 +274,7 @@ public class TripController {
     @PreAuthorize("hasRole('CLIENT')")
     @PostMapping("/request/{requestId}/end")
     public ResponseEntity<ApiResponse<MessageResponse>> endTrip(
-            @Parameter(description = "The unique ID of the request assigned with trip", required = true) @PathVariable Long requestId,
-            @Parameter(description = "Bearer authorization token", required = true) @RequestHeader("Authorization") String token) {
+            @Parameter(description = "The unique ID of the request assigned with trip", required = true) @PathVariable Long requestId) {
         try {
             tripService.endTrip(requestId);
             return ResponseEntity

--- a/src/main/java/com/yaquodorg/yaquod/controller/TripController.java
+++ b/src/main/java/com/yaquodorg/yaquod/controller/TripController.java
@@ -30,7 +30,6 @@ import static com.yaquodorg.yaquod.response.ApiResponse.createSuccessResponse;
 @Tag(name = "Trips", description = "Trip management and request APIs")
 public class TripController {
 
-
     private final RequestService requestService;
     private final TripService tripService;
 
@@ -41,7 +40,7 @@ public class TripController {
     })
     @PostMapping("/request")
     public ResponseEntity<ApiResponse<Request>> createRequest(@RequestBody TripRequestDto tripRequestDto,
-                                                              @AuthenticationPrincipal User user) {
+            @AuthenticationPrincipal User user) {
         try {
             Request request = requestService.createRequest(user.getId(),
                     tripRequestDto.getStartLong(),
@@ -64,8 +63,7 @@ public class TripController {
     })
     @GetMapping("/request/status/{requestId}")
     public ResponseEntity<ApiResponse<Request>> getRequest(
-            @Parameter(description = "The unique ID of the request", required = true)
-            @PathVariable Long requestId) {
+            @Parameter(description = "The unique ID of the request", required = true) @PathVariable Long requestId) {
         try {
             Request request = requestService.getRequest(requestId);
             return ResponseEntity
@@ -83,8 +81,7 @@ public class TripController {
     })
     @GetMapping("/by-request/{requestId}")
     public ResponseEntity<ApiResponse<Trip>> getTripByRequestId(
-            @Parameter(description = "The unique ID of the request", required = true)
-            @PathVariable Long requestId) {
+            @Parameter(description = "The unique ID of the request", required = true) @PathVariable Long requestId) {
         try {
             Trip trip = tripService.getTripByRequestId(requestId);
             return ResponseEntity
@@ -102,8 +99,7 @@ public class TripController {
     })
     @GetMapping("/{tripId}")
     public ResponseEntity<ApiResponse<Trip>> getTripById(
-            @Parameter(description = "The unique database ID of the trip", required = true)
-            @PathVariable Long tripId) {
+            @Parameter(description = "The unique database ID of the trip", required = true) @PathVariable Long tripId) {
         try {
             Trip trip = tripService.getTripById(tripId);
             return ResponseEntity
@@ -123,8 +119,7 @@ public class TripController {
     @PreAuthorize("hasRole('ADMIN')")
     @DeleteMapping("/{tripId}")
     public ResponseEntity<ApiResponse<MessageResponse>> deleteTripById(
-            @Parameter(description = "The unique database ID of the trip to delete", required = true)
-            @PathVariable Long tripId) {
+            @Parameter(description = "The unique database ID of the trip to delete", required = true) @PathVariable Long tripId) {
         try {
             tripService.deleteTripById(tripId);
             return ResponseEntity
@@ -176,8 +171,7 @@ public class TripController {
     })
     @GetMapping("/last/{n}")
     public ResponseEntity<ApiResponse<List<Trip>>> getLastNTrips(
-            @Parameter(description = "Number of recent trips to retrieve", required = true, example = "5")
-            @PathVariable int n,
+            @Parameter(description = "Number of recent trips to retrieve", required = true, example = "5") @PathVariable int n,
             @AuthenticationPrincipal User user) {
         try {
             List<Trip> trips = tripService.getUserLastNTrips(n, user.getId());
@@ -196,8 +190,7 @@ public class TripController {
     })
     @GetMapping("/vehicle/{vinNumber}")
     public ResponseEntity<ApiResponse<List<Trip>>> getTripsByVinNumber(
-            @Parameter(description = "The Vehicle Identification Number (VIN)", required = true, example = "1HGBH41JXMN109186")
-            @PathVariable String vinNumber) {
+            @Parameter(description = "The Vehicle Identification Number (VIN)", required = true, example = "1HGBH41JXMN109186") @PathVariable String vinNumber) {
         try {
             List<Trip> trips = tripService.getTripsByVinNumber(vinNumber);
             return ResponseEntity
@@ -217,10 +210,8 @@ public class TripController {
     @PreAuthorize("hasRole('CLIENT')")
     @PostMapping("/request/{requestId}/decline")
     public ResponseEntity<ApiResponse<MessageResponse>> declineRequest(
-            @Parameter(description = "The unique ID of the request to decline", required = true)
-            @PathVariable Long requestId,
-            @Parameter(description = "Bearer authorization token", required = true)
-            @RequestHeader("Authorization") String token) {
+            @Parameter(description = "The unique ID of the request to decline", required = true) @PathVariable Long requestId,
+            @Parameter(description = "Bearer authorization token", required = true) @RequestHeader("Authorization") String token) {
         try {
             requestService.declineRequestById(requestId, token);
             return ResponseEntity
@@ -240,10 +231,8 @@ public class TripController {
     @PreAuthorize("hasRole('CLIENT')")
     @PostMapping("/request/{requestId}/accept")
     public ResponseEntity<ApiResponse<Request>> acceptRequest(
-            @Parameter(description = "The unique ID of the request to accept", required = true)
-            @PathVariable Long requestId,
-            @Parameter(description = "Bearer authorization token", required = true)
-            @RequestHeader("Authorization") String token) {
+            @Parameter(description = "The unique ID of the request to accept", required = true) @PathVariable Long requestId,
+            @Parameter(description = "Bearer authorization token", required = true) @RequestHeader("Authorization") String token) {
         try {
 
             Request request = requestService.acceptRequestById(requestId, token);
@@ -252,6 +241,27 @@ public class TripController {
         } catch (Exception e) {
             return ResponseEntity.badRequest()
                     .body(ApiResponse.createFailureResponse("Failed to accept Request: " + e.getMessage()));
+        }
+    }
+
+    @Operation(summary = "Start a trip", description = "Moves vehicle and starts trip. Requires CLIENT role.")
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Trip started successfully"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "Failed to start trip"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Access denied - requires CLIENT role")
+    })
+    @PreAuthorize("hasRole('CLIENT')")
+    @PostMapping("/request/{requestId}/start")
+    public ResponseEntity<ApiResponse<MessageResponse>> startTrip(
+            @Parameter(description = "The unique ID of the request assigned with trip", required = true) @PathVariable Long requestId,
+            @Parameter(description = "Bearer authorization token", required = true) @RequestHeader("Authorization") String token) {
+        try {
+            tripService.startTrip(requestId);
+            return ResponseEntity
+                    .ok(ApiResponse.createSuccessResponse(new MessageResponse("Trip started successfully!")));
+        } catch (Exception e) {
+            return ResponseEntity.badRequest()
+                    .body(ApiResponse.createFailureResponse("Failed to start trip: " + e.getMessage()));
         }
     }
 }

--- a/src/main/java/com/yaquodorg/yaquod/dtos/VehicleDto.java
+++ b/src/main/java/com/yaquodorg/yaquod/dtos/VehicleDto.java
@@ -1,10 +1,12 @@
 package com.yaquodorg.yaquod.dtos;
 
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
 
 @Data
 @AllArgsConstructor
+@Builder
 public class VehicleDto {
     // @ValidVIN
     private String vinNumber;

--- a/src/main/java/com/yaquodorg/yaquod/service/mqtt/MqttService.java
+++ b/src/main/java/com/yaquodorg/yaquod/service/mqtt/MqttService.java
@@ -1,34 +1,21 @@
 package com.yaquodorg.yaquod.service.mqtt;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.yaquodorg.yaquod.dtos.*;
+import com.yaquodorg.yaquod.entity.*;
+import com.yaquodorg.yaquod.service.messaging.FirebaseMessagingService;
+import com.yaquodorg.yaquod.service.request.RequestService;
+import com.yaquodorg.yaquod.service.trip.TripService;
+import com.yaquodorg.yaquod.service.vehicle.VehicleService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.locationtech.jts.geom.Point;
 import org.springframework.context.event.EventListener;
 import org.springframework.integration.annotation.ServiceActivator;
 import org.springframework.integration.mqtt.support.MqttHeaders;
 import org.springframework.messaging.Message;
 import org.springframework.stereotype.Service;
-
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.yaquodorg.yaquod.dtos.EtaStatusDto;
-import com.yaquodorg.yaquod.dtos.InitTripDto;
-import com.yaquodorg.yaquod.dtos.MoveVehicleDto;
-import com.yaquodorg.yaquod.dtos.UpdateTripStatusDto;
-import com.yaquodorg.yaquod.dtos.UpdateVehicleLocationDto;
-import com.yaquodorg.yaquod.dtos.UpdateVehicleStatusDto;
-import com.yaquodorg.yaquod.dtos.VehicleArrivalDto;
-import com.yaquodorg.yaquod.entity.Request;
-import com.yaquodorg.yaquod.entity.Trip;
-import com.yaquodorg.yaquod.entity.TripStatus;
-import com.yaquodorg.yaquod.entity.User;
-import com.yaquodorg.yaquod.entity.Vehicle;
-import com.yaquodorg.yaquod.entity.VehicleStatus;
-import com.yaquodorg.yaquod.service.messaging.FirebaseMessagingService;
-import com.yaquodorg.yaquod.service.request.RequestService;
-import com.yaquodorg.yaquod.service.trip.TripService;
-import com.yaquodorg.yaquod.service.vehicle.VehicleService;
-
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @Service
@@ -42,6 +29,8 @@ public class MqttService {
     private static final String TOPIC_TRIP_MOVE = "topic/trip/move";
     private static final String TOPIC_TRIP_ARRIVE = "topic/trip/arrive";
     private static final String TOPIC_TRIP_STATUS = "topic/trip/status";
+    private static final String TOPIC_ORDER_UPDATE_LOCATION = "topic/update_location/order";
+    private static final String TOPIC_ORDER_UPDATE_STATUS = "topic/update_status/order";
 
     private final MqttGateway mqttGateway;
     private final ObjectMapper objectMapper;
@@ -202,6 +191,12 @@ public class MqttService {
     @EventListener
     public void handleMoveVehicleOrder(MoveVehicleDto event) {
         publish(TOPIC_TRIP_MOVE, event);
+    }
+
+    @EventListener
+    public void handleOrderVehicleUpdateOrder(VehicleDto event) {
+        publish(TOPIC_ORDER_UPDATE_LOCATION, event);
+        publish(TOPIC_ORDER_UPDATE_STATUS, event);
     }
 
 }

--- a/src/main/java/com/yaquodorg/yaquod/service/mqtt/MqttService.java
+++ b/src/main/java/com/yaquodorg/yaquod/service/mqtt/MqttService.java
@@ -11,11 +11,12 @@ import com.yaquodorg.yaquod.service.vehicle.VehicleService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.locationtech.jts.geom.Point;
-import org.springframework.context.event.EventListener;
 import org.springframework.integration.annotation.ServiceActivator;
 import org.springframework.integration.mqtt.support.MqttHeaders;
 import org.springframework.messaging.Message;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
 
 @Slf4j
 @Service
@@ -183,17 +184,17 @@ public class MqttService {
         }
     }
 
-    @EventListener
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleTripInitiated(InitTripDto event) {
         publish(TOPIC_INIT_TRIP, event);
     }
 
-    @EventListener
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleMoveVehicleOrder(MoveVehicleDto event) {
         publish(TOPIC_TRIP_MOVE, event);
     }
 
-    @EventListener
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleOrderVehicleUpdateOrder(VehicleDto event) {
         publish(TOPIC_ORDER_UPDATE_LOCATION, event);
         publish(TOPIC_ORDER_UPDATE_STATUS, event);

--- a/src/main/java/com/yaquodorg/yaquod/service/request/RequestService.java
+++ b/src/main/java/com/yaquodorg/yaquod/service/request/RequestService.java
@@ -2,7 +2,6 @@ package com.yaquodorg.yaquod.service.request;
 
 import java.util.List;
 
-import com.yaquodorg.yaquod.dtos.MoveVehicleDto;
 import com.yaquodorg.yaquod.entity.Request;
 import com.yaquodorg.yaquod.entity.RequestStatus;
 
@@ -24,6 +23,4 @@ public interface RequestService {
     void declineRequestById(Long id, String token);
 
     Request acceptRequestById(Long id, String token);
-
-    MoveVehicleDto generateVehicleMovementDto(Long requestId);
 }

--- a/src/main/java/com/yaquodorg/yaquod/service/request/RequestServiceImpl.java
+++ b/src/main/java/com/yaquodorg/yaquod/service/request/RequestServiceImpl.java
@@ -130,42 +130,38 @@ public class RequestServiceImpl implements RequestService {
     public Request acceptRequestById(Long id, String token) {
         User user = userService.getUserByJwt(token);
         Request request = getRequest(id);
+
         if (!request.getUser().getId().equals(user.getId())) {
             throw new RuntimeException("Unauthorized to accept this request");
-        } else {
-            // publish to broker
-            MoveVehicleDto moveVehicleDto = generateVehicleMovementDto(id);
-            eventPublisher.publishEvent(moveVehicleDto);
-
-            updateRequestStatus(id, RequestStatus.ACCEPTED);
-            log.info("Request with id {} has been accepted.", id);
-
-            Trip trip = request.getTrip();
-            long tripId = trip.getId();
-            tripService.updateTripStatus(tripId, TripStatus.VEHICLE_ON_WAY);
-            log.info("Accepting associated trip with id {}.", tripId);
-
-            Vehicle vehicle = trip.getVehicle();
-            if (vehicle != null) {
-                String vinNumber = vehicle.getVinNumber();
-                vehicleService.updateVehicleStatus(vinNumber, VehicleStatus.ON_WAY);
-                log.info("Returning vehicle status with vin: {} to ON_WAY", vinNumber);
-            }
-
-            return request;
         }
 
+        Trip trip = request.getTrip();
+        long tripId = trip.getId();
+        Vehicle vehicle = trip.getVehicle();
+        String vinNumber = vehicle.getVinNumber();
+        Point startLocation = request.getStartLocation();
+
+        // TODO: I think we should validate the current states of both the trip and the
+        // vehicle before ordering the vehicle to move and update their statuses
+
+        // publish to broker
+        MoveVehicleDto moveVehicleDto = generateVehicleMovementDto(startLocation, tripId, vinNumber);
+        eventPublisher.publishEvent(moveVehicleDto);
+
+        // Update statuses
+        updateRequestStatus(id, RequestStatus.ACCEPTED);
+        log.info("Request with id {} has been accepted.", id);
+
+        tripService.updateTripStatus(tripId, TripStatus.VEHICLE_ON_WAY);
+        log.info("Accepting associated trip with id {}.", tripId);
+
+        vehicleService.updateVehicleStatus(vinNumber, VehicleStatus.ON_WAY);
+        log.info("Returning vehicle status with vin: {} to ON_WAY", vinNumber);
+
+        return request;
     }
 
-    @Override
-    public MoveVehicleDto generateVehicleMovementDto(Long requestId) {
-        Request request = getRequest(requestId);
-        Trip trip = request.getTrip();
-        Vehicle vehicle = trip.getVehicle();
-
-        String vinNumber = vehicle.getVinNumber();
-        long tripId = trip.getId();
-        Point startLocation = request.getStartLocation();
+    private MoveVehicleDto generateVehicleMovementDto(Point startLocation, Long tripId, String vinNumber) {
         double startLat = startLocation.getY();
         double startLong = startLocation.getX();
 

--- a/src/main/java/com/yaquodorg/yaquod/service/trip/TripService.java
+++ b/src/main/java/com/yaquodorg/yaquod/service/trip/TripService.java
@@ -13,8 +13,6 @@ public interface TripService {
 
     Trip getTripById(Long id);
 
-    // Trip updateTrip(Long id, Trip updatedTrip);
-
     List<Trip> getAllTrips();
 
     List<Trip> getTripsByUserId(Long userId);
@@ -26,4 +24,6 @@ public interface TripService {
     void updateTripStatus(Long id, TripStatus tripStatus);
 
     void deleteTripById(Long id);
+
+    void startTrip(Long requestId);
 }

--- a/src/main/java/com/yaquodorg/yaquod/service/trip/TripService.java
+++ b/src/main/java/com/yaquodorg/yaquod/service/trip/TripService.java
@@ -26,4 +26,6 @@ public interface TripService {
     void deleteTripById(Long id);
 
     void startTrip(Long requestId);
+
+    void endTrip(Long requestId);
 }

--- a/src/main/java/com/yaquodorg/yaquod/service/trip/TripServiceImpl.java
+++ b/src/main/java/com/yaquodorg/yaquod/service/trip/TripServiceImpl.java
@@ -4,12 +4,14 @@ import java.sql.Timestamp;
 import java.util.Date;
 import java.util.List;
 
+import org.locationtech.jts.geom.Point;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.yaquodorg.yaquod.dtos.InitTripDto;
+import com.yaquodorg.yaquod.dtos.MoveVehicleDto;
 import com.yaquodorg.yaquod.entity.Request;
 import com.yaquodorg.yaquod.entity.Trip;
 import com.yaquodorg.yaquod.entity.TripStatus;
@@ -136,5 +138,49 @@ public class TripServiceImpl implements TripService {
                 () -> new RuntimeException("Vehicle not found for vin number: " + vinNumber));
 
         return tripRepository.findByVehicleVinNumber(vehicle.getVinNumber());
+    }
+
+    @Transactional
+    @Override
+    public void startTrip(Long requestId) {
+        Trip trip = getTripByRequestId(requestId);
+        Long tripId = trip.getId();
+
+        Vehicle vehicle = trip.getVehicle();
+        if (vehicle == null) {
+            log.error("No vehicle was matched with trip: {}", tripId);
+            throw new RuntimeException("No vehicle was matched with trip: " + tripId);
+        }
+        String vinNumber = vehicle.getVinNumber();
+
+        Request request = trip.getRequest();
+        if (request == null) {
+            log.error("Trip: {} was not assigned with a request", tripId);
+            throw new RuntimeException("Trip: " + tripId + " was not assigned with a request");
+        }
+        Point destinationLocation = request.getDestinationLocation();
+
+        // TODO: I think we should validate the current states of both the trip and the
+        // vehicle before ordering the vehicle to move and update their statuses
+
+        // Send moving signal to the vehicle with the destination location
+        MoveVehicleDto moveVehicleDto = buildMoveVehicleDto(vinNumber, tripId, destinationLocation);
+        eventPublisher.publishEvent(moveVehicleDto);
+
+        // Update vehicle and trip statuses
+        vehicleService.updateVehicleStatus(vinNumber, VehicleStatus.IN_USE);
+        updateTripStatus(tripId, TripStatus.IN_PROGRESS);
+    }
+
+    private MoveVehicleDto buildMoveVehicleDto(String vinNumber, Long tripId, Point destinationLocation) {
+        double destinationLat = destinationLocation.getY();
+        double destinationLong = destinationLocation.getX();
+
+        return MoveVehicleDto.builder()
+                .vinNumber(vinNumber)
+                .tripId(tripId)
+                .latitude(destinationLat)
+                .longitude(destinationLong)
+                .build();
     }
 }

--- a/src/main/java/com/yaquodorg/yaquod/service/trip/TripServiceImpl.java
+++ b/src/main/java/com/yaquodorg/yaquod/service/trip/TripServiceImpl.java
@@ -1,29 +1,23 @@
 package com.yaquodorg.yaquod.service.trip;
 
-import java.sql.Timestamp;
-import java.util.Date;
-import java.util.List;
-
+import com.yaquodorg.yaquod.dtos.InitTripDto;
+import com.yaquodorg.yaquod.dtos.MoveVehicleDto;
+import com.yaquodorg.yaquod.dtos.VehicleDto;
+import com.yaquodorg.yaquod.entity.*;
+import com.yaquodorg.yaquod.repository.TripRepository;
+import com.yaquodorg.yaquod.service.user.UserService;
+import com.yaquodorg.yaquod.service.vehicle.VehicleService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.locationtech.jts.geom.Point;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.yaquodorg.yaquod.dtos.InitTripDto;
-import com.yaquodorg.yaquod.dtos.MoveVehicleDto;
-import com.yaquodorg.yaquod.entity.Request;
-import com.yaquodorg.yaquod.entity.Trip;
-import com.yaquodorg.yaquod.entity.TripStatus;
-import com.yaquodorg.yaquod.entity.User;
-import com.yaquodorg.yaquod.entity.Vehicle;
-import com.yaquodorg.yaquod.entity.VehicleStatus;
-import com.yaquodorg.yaquod.repository.TripRepository;
-import com.yaquodorg.yaquod.service.user.UserService;
-import com.yaquodorg.yaquod.service.vehicle.VehicleService;
-
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+import java.sql.Timestamp;
+import java.util.Date;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -143,22 +137,10 @@ public class TripServiceImpl implements TripService {
     @Transactional
     @Override
     public void startTrip(Long requestId) {
-        Trip trip = getTripByRequestId(requestId);
+        Trip trip = getValidatedTrip(requestId);
         Long tripId = trip.getId();
-
-        Vehicle vehicle = trip.getVehicle();
-        if (vehicle == null) {
-            log.error("No vehicle was matched with trip: {}", tripId);
-            throw new RuntimeException("No vehicle was matched with trip: " + tripId);
-        }
-        String vinNumber = vehicle.getVinNumber();
-
-        Request request = trip.getRequest();
-        if (request == null) {
-            log.error("Trip: {} was not assigned with a request", tripId);
-            throw new RuntimeException("Trip: " + tripId + " was not assigned with a request");
-        }
-        Point destinationLocation = request.getDestinationLocation();
+        String vinNumber = trip.getVehicle().getVinNumber();
+        Point destinationLocation = trip.getRequest().getDestinationLocation();
 
         // TODO: I think we should validate the current states of both the trip and the
         // vehicle before ordering the vehicle to move and update their statuses
@@ -170,6 +152,43 @@ public class TripServiceImpl implements TripService {
         // Update vehicle and trip statuses
         vehicleService.updateVehicleStatus(vinNumber, VehicleStatus.IN_USE);
         updateTripStatus(tripId, TripStatus.IN_PROGRESS);
+    }
+
+    @Override
+    @Transactional
+    public void endTrip(Long requestId) {
+        Trip trip = getValidatedTrip(requestId);
+        Long tripId = trip.getId();
+        String vinNumber = trip.getVehicle().getVinNumber();
+
+        VehicleDto vehicleDto = VehicleDto.builder()
+                .vinNumber(vinNumber)
+                .build();
+
+        eventPublisher.publishEvent(vehicleDto);
+
+        // Update vehicle and trip statuses
+        vehicleService.updateVehicleStatus(vinNumber, VehicleStatus.IDLE);
+        updateTripStatus(tripId, TripStatus.COMPLETED);
+    }
+
+    private Trip getValidatedTrip(Long requestId) {
+        Trip trip = getTripByRequestId(requestId);
+        Long tripId = trip.getId();
+
+        Vehicle vehicle = trip.getVehicle();
+        if (vehicle == null) {
+            log.error("No vehicle was matched with trip: {}", tripId);
+            throw new RuntimeException("No vehicle was matched with trip: " + tripId);
+        }
+
+        Request request = trip.getRequest();
+        if (request == null) {
+            log.error("Trip: {} was not assigned with a request", tripId);
+            throw new RuntimeException("Trip: " + tripId + " was not assigned with a request");
+        }
+
+        return trip;
     }
 
     private MoveVehicleDto buildMoveVehicleDto(String vinNumber, Long tripId, Point destinationLocation) {

--- a/src/test/java/com/yaquodorg/yaquod/controller/TripControllerIntegrationTest.java
+++ b/src/test/java/com/yaquodorg/yaquod/controller/TripControllerIntegrationTest.java
@@ -351,8 +351,8 @@ class TripControllerIntegrationTest {
     void shouldReturn401WhenNotAuthenticated() throws Exception {
         // Act & Assert
         mockMvc.perform(post("/api/trips/request")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(tripRequestDto)))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(tripRequestDto)))
                 .andExpect(status().isUnauthorized());
     }
 
@@ -362,8 +362,8 @@ class TripControllerIntegrationTest {
     void shouldHandleInvalidJsonPayload() throws Exception {
         // Act & Assert
         mockMvc.perform(post("/api/trips/request")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("{invalid json"))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{invalid json"))
                 .andExpect(status().isBadRequest());
     }
 
@@ -398,8 +398,8 @@ class TripControllerIntegrationTest {
 
         // Act & Assert
         mockMvc.perform(post("/api/trips/request")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(invalidDto)))
-                .andExpect(status().isBadRequest());
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(invalidDto)))
+                .andExpect(status().isForbidden());
     }
 }


### PR DESCRIPTION
## Summary
- Added endpoints for starting and ending trips with proper client authorization
- Implemented trip start functionality that sends move signals to vehicles and updates statuses
- Implemented trip end functionality that updates vehicle status to IDLE and trip status to COMPLETED
- Enhanced MQTT service to handle vehicle location and status update events
- Refactored accept offer logic to eliminate obsolete database queries and remove boilerplate code

## Changes Made

### New Endpoints
- **POST `/trip/request/{requestId}/start`** - Start a trip, move vehicle to destination, and update statuses (CLIENT role required)
- **POST `/trip/request/{requestId}/end`** - End a trip and update vehicle status (CLIENT role required)

### Service Layer
- Added `startTrip()` and `endTrip()` methods in `TripService`
- Implemented trip validation logic to ensure vehicle and request are properly assigned
- Added `buildMoveVehicleDto()` helper method for creating vehicle movement DTOs
- Enhanced MQTT service with new topics: `topic/update_location/order` and `topic/update_status/order`

### Code Quality
- Refactored `acceptRequestById()` to remove obsolete database queries
- Moved `generateVehicleMovementDto()` from public interface to private helper method
- Added `@Builder` annotation to `VehicleDto` for cleaner object construction
- Improved code formatting and reduced boilerplate
