### PR TITLE
refactor: Update QoS default value to 2 in MqttConfig and add detaile…

### DIFF
--- a/src/main/java/com/yaquodorg/yaquod/config/MqttConfig.java
+++ b/src/main/java/com/yaquodorg/yaquod/config/MqttConfig.java
@@ -29,24 +29,24 @@ public class MqttConfig {
     private String clientId;
     private String[] topics;
     /*
-  Use QoS 1 when:
-  • You need to get every message and your use case can
-  handle duplicates. QoS level 1 is the most frequently used
-  service level because it guarantees the message arrives
-  at least once but allows for multiple deliveries. Of course,
-  your application must tolerate duplicates and be able to
-  process them accordingly.
-  • You can’t bear the overhead of QoS 2. QoS 1 delivers
-  messages much faster than QoS 2.
-  Use QoS 2 when:
-  • It is critical to your application to receive all messages
-  exactly once. This is often the case if a duplicate delivery
-  can harm application users or subscribing clients. Be
-  aware of the overhead and that the QoS 2 interaction
-  takes more time to complete.
+    Use QoS 1 when:
+    • You need to get every message and your use case can
+    handle duplicates. QoS level 1 is the most frequently used
+    service level because it guarantees the message arrives
+    at least once but allows for multiple deliveries. Of course,
+    your application must tolerate duplicates and be able to
+    process them accordingly.
+    • You can’t bear the overhead of QoS 2. QoS 1 delivers
+    messages much faster than QoS 2.
+    Use QoS 2 when:
+    • It is critical to your application to receive all messages
+    exactly once. This is often the case if a duplicate delivery
+    can harm application users or subscribing clients. Be
+    aware of the overhead and that the QoS 2 interaction
+    takes more time to complete.
 
-  source : hivemq-ebook-mqtt-essentials.pdf
-   */
+    source : hivemq-ebook-mqtt-essentials.pdf
+     */
     private int qos = 2;
     private int connectionTimeout = 60;
     private int keepAliveInterval = 60;
@@ -61,7 +61,7 @@ public class MqttConfig {
 
         log.info("Connecting to MQTT Broker at: {}", resolvedUrl);
 
-        options.setServerURIs(new String[]{resolvedUrl});
+        options.setServerURIs(new String[] {resolvedUrl});
         options.setConnectionTimeout(connectionTimeout);
         options.setKeepAliveInterval(keepAliveInterval);
         options.setCleanSession(true);

--- a/src/main/java/com/yaquodorg/yaquod/config/MqttConfig.java
+++ b/src/main/java/com/yaquodorg/yaquod/config/MqttConfig.java
@@ -28,7 +28,26 @@ public class MqttConfig {
     private String brokerUrl;
     private String clientId;
     private String[] topics;
-    private int qos = 1;
+    /*
+  Use QoS 1 when:
+  • You need to get every message and your use case can
+  handle duplicates. QoS level 1 is the most frequently used
+  service level because it guarantees the message arrives
+  at least once but allows for multiple deliveries. Of course,
+  your application must tolerate duplicates and be able to
+  process them accordingly.
+  • You can’t bear the overhead of QoS 2. QoS 1 delivers
+  messages much faster than QoS 2.
+  Use QoS 2 when:
+  • It is critical to your application to receive all messages
+  exactly once. This is often the case if a duplicate delivery
+  can harm application users or subscribing clients. Be
+  aware of the overhead and that the QoS 2 interaction
+  takes more time to complete.
+
+  source : hivemq-ebook-mqtt-essentials.pdf
+   */
+    private int qos = 2;
     private int connectionTimeout = 60;
     private int keepAliveInterval = 60;
 
@@ -42,7 +61,7 @@ public class MqttConfig {
 
         log.info("Connecting to MQTT Broker at: {}", resolvedUrl);
 
-        options.setServerURIs(new String[] {resolvedUrl});
+        options.setServerURIs(new String[]{resolvedUrl});
         options.setConnectionTimeout(connectionTimeout);
         options.setKeepAliveInterval(keepAliveInterval);
         options.setCleanSession(true);

--- a/src/main/java/com/yaquodorg/yaquod/service/mqtt/MqttService.java
+++ b/src/main/java/com/yaquodorg/yaquod/service/mqtt/MqttService.java
@@ -23,9 +23,11 @@ import org.springframework.transaction.event.TransactionalEventListener;
 @RequiredArgsConstructor
 public class MqttService {
 
-    private static final String TOPIC_VEHICLE_UPDATE_LOCATION_ORDER = "topic/vehicle/update/location/order";
+    private static final String TOPIC_VEHICLE_UPDATE_LOCATION_ORDER =
+            "topic/vehicle/update/location/order";
     private static final String TOPIC_VEHICLE_UPDATE_LOCATION = "topic/vehicle/update/location";
-    private static final String TOPIC_VEHICLE_UPDATE_STATUS_ORDER = "topic/vehicle/update/status/order";
+    private static final String TOPIC_VEHICLE_UPDATE_STATUS_ORDER =
+            "topic/vehicle/update/status/order";
     private static final String TOPIC_VEHICLE_UPDATE_STATUS = "topic/vehicle/update/status";
     private static final String TOPIC_TRIP_INIT = "topic/trip/init";
     private static final String TOPIC_TRIP_ETA = "topic/trip/eta";
@@ -46,26 +48,40 @@ public class MqttService {
         String topic = (String) message.getHeaders().get(MqttHeaders.RECEIVED_TOPIC);
         String payload = message.getPayload().toString();
 
-        if (TOPIC_VEHICLE_UPDATE_LOCATION.equals(topic)) {
-            handleVehicleUpdateLocation(payload);
-        } else if (TOPIC_VEHICLE_UPDATE_STATUS.equals(topic)) {
-            handleVehicleUpdateStatus(payload);
-        } else if (TOPIC_TRIP_ETA.equals(topic)) {
-            handleVehicleUpdateEta(payload);
-        } else if (TOPIC_TRIP_ARRIVE.equals(topic)) {
-            handleVehicleArrival(payload);
-        } else if (TOPIC_TRIP_STATUS.equals(topic)) {
-            handleVehicleUpdateTripStatus(payload);
-        } else if (TOPIC_VEHICLE_UPDATE_LOCATION_ORDER.equals(topic)) {
-            log.info("Sent vehicle update location order successfully!");
-        } else if (TOPIC_VEHICLE_UPDATE_STATUS_ORDER.equals(topic)) {
-            log.info("Sent vehicle update status order successfully!");
-        } else if (TOPIC_TRIP_INIT.equals(topic)) {
-            log.info("Sent trip init order successfully!");
-        } else if (TOPIC_TRIP_MOVE.equals(topic)) {
-            log.info("Sent trip move order successfully!");
-        } else {
-            log.warn("Unhandled topic: {}", topic);
+        switch (topic) {
+            case TOPIC_VEHICLE_UPDATE_LOCATION:
+                handleVehicleUpdateLocation(payload);
+                break;
+            case TOPIC_VEHICLE_UPDATE_STATUS:
+                handleVehicleUpdateStatus(payload);
+                break;
+            case TOPIC_TRIP_ETA:
+                handleVehicleUpdateEta(payload);
+                break;
+            case TOPIC_TRIP_ARRIVE:
+                handleVehicleArrival(payload);
+                break;
+            case TOPIC_TRIP_STATUS:
+                handleVehicleUpdateTripStatus(payload);
+                break;
+            case TOPIC_VEHICLE_UPDATE_LOCATION_ORDER:
+                log.info("Sent vehicle update location order successfully!");
+                break;
+            case TOPIC_VEHICLE_UPDATE_STATUS_ORDER:
+                log.info("Sent vehicle update status order successfully!");
+                break;
+            case TOPIC_TRIP_INIT:
+                log.info("Sent trip init order successfully!");
+                break;
+            case TOPIC_TRIP_MOVE:
+                log.info("Sent trip move order successfully!");
+                break;
+            case null:
+                log.warn("Received message with null topic");
+                return;
+            default:
+                log.warn("Unhandled topic: {}", topic);
+                break;
         }
 
         log.info("Received message from topic '{}': {}", topic, payload);

--- a/src/main/java/com/yaquodorg/yaquod/service/mqtt/MqttService.java
+++ b/src/main/java/com/yaquodorg/yaquod/service/mqtt/MqttService.java
@@ -23,12 +23,12 @@ import org.springframework.transaction.event.TransactionalEventListener;
 @RequiredArgsConstructor
 public class MqttService {
 
-    private static final String TOPIC_ORDER_UPDATE_LOCATION = "topic/vehicle/update/location/order";
-    private static final String TOPIC_UPDATE_LOCATION = "topic/vehicle/update/location";
-    private static final String TOPIC_ORDER_UPDATE_STATUS = "topic/vehicle/update/status/order";
-    private static final String TOPIC_UPDATE_STATUS = "topic/vehicle/update/status";
-    private static final String TOPIC_INIT_TRIP = "topic/trip/init";
-    private static final String TOPIC_ETA_TRIP = "topic/trip/eta";
+    private static final String TOPIC_VEHICLE_UPDATE_LOCATION_ORDER = "topic/vehicle/update/location/order";
+    private static final String TOPIC_VEHICLE_UPDATE_LOCATION = "topic/vehicle/update/location";
+    private static final String TOPIC_VEHICLE_UPDATE_STATUS_ORDER = "topic/vehicle/update/status/order";
+    private static final String TOPIC_VEHICLE_UPDATE_STATUS = "topic/vehicle/update/status";
+    private static final String TOPIC_TRIP_INIT = "topic/trip/init";
+    private static final String TOPIC_TRIP_ETA = "topic/trip/eta";
     private static final String TOPIC_TRIP_MOVE = "topic/trip/move";
     private static final String TOPIC_TRIP_ARRIVE = "topic/trip/arrive";
     private static final String TOPIC_TRIP_STATUS = "topic/trip/status";
@@ -46,16 +46,24 @@ public class MqttService {
         String topic = (String) message.getHeaders().get(MqttHeaders.RECEIVED_TOPIC);
         String payload = message.getPayload().toString();
 
-        if (TOPIC_UPDATE_LOCATION.equals(topic)) {
+        if (TOPIC_VEHICLE_UPDATE_LOCATION.equals(topic)) {
             handleVehicleUpdateLocation(payload);
-        } else if (TOPIC_UPDATE_STATUS.equals(topic)) {
+        } else if (TOPIC_VEHICLE_UPDATE_STATUS.equals(topic)) {
             handleVehicleUpdateStatus(payload);
-        } else if (TOPIC_ETA_TRIP.equals(topic)) {
+        } else if (TOPIC_TRIP_ETA.equals(topic)) {
             handleVehicleUpdateEta(payload);
         } else if (TOPIC_TRIP_ARRIVE.equals(topic)) {
             handleVehicleArrival(payload);
         } else if (TOPIC_TRIP_STATUS.equals(topic)) {
             handleVehicleUpdateTripStatus(payload);
+        } else if (TOPIC_VEHICLE_UPDATE_LOCATION_ORDER.equals(topic)) {
+            log.info("Sent vehicle update location order successfully!");
+        } else if (TOPIC_VEHICLE_UPDATE_STATUS_ORDER.equals(topic)) {
+            log.info("Sent vehicle update status order successfully!");
+        } else if (TOPIC_TRIP_INIT.equals(topic)) {
+            log.info("Sent trip init order successfully!");
+        } else if (TOPIC_TRIP_MOVE.equals(topic)) {
+            log.info("Sent trip move order successfully!");
         } else {
             log.warn("Unhandled topic: {}", topic);
         }
@@ -209,7 +217,7 @@ public class MqttService {
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleTripInitiated(InitTripDto event) {
-        publish(TOPIC_INIT_TRIP, event);
+        publish(TOPIC_TRIP_INIT, event);
     }
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
@@ -219,7 +227,7 @@ public class MqttService {
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleOrderVehicleUpdateOrder(VehicleDto event) {
-        publish(TOPIC_ORDER_UPDATE_LOCATION, event);
-        publish(TOPIC_ORDER_UPDATE_STATUS, event);
+        publish(TOPIC_VEHICLE_UPDATE_LOCATION_ORDER, event);
+        publish(TOPIC_VEHICLE_UPDATE_STATUS_ORDER, event);
     }
 }


### PR DESCRIPTION
This pull request updates the default Quality of Service (QoS) level for MQTT messaging in the `MqttConfig` class and adds documentation to clarify when to use different QoS levels.

MQTT configuration improvements:

* Changed the default value of the `qos` field in `MqttConfig` from 1 to 2, ensuring messages are delivered exactly once by default.
* Added a detailed comment explaining the differences between QoS 1 and QoS 2, including guidance on when to use each and referencing the "hivemq-ebook-mqtt-essentials.pdf" source.
* The QOS 2 will act good in case of car usage because it's critical to the car to do the same action twice.