### PR TITLE
Implemented Trip Request Cancellation and Vehicle Stop Logic.

### DIFF
--- a/src/main/java/com/yaquodorg/yaquod/controller/TripController.java
+++ b/src/main/java/com/yaquodorg/yaquod/controller/TripController.java
@@ -92,6 +92,29 @@ public class TripController {
     }
 
     @Operation(
+            summary = "Cancel Request",
+            description = "Cancels the current request and order vehicle to stop ETA calculations")
+    @ApiResponses(
+            value = {
+                @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                        responseCode = "200",
+                        description = "Request canceled successfully"),
+                @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                        responseCode = "404",
+                        description = "Request not found")
+            })
+    @PreAuthorize("hasAnyRole('CLIENT', 'ADMIN')")
+    @DeleteMapping("/request/{requestId}")
+    public ResponseEntity<ApiResponse<MessageResponse>> cancelRequest(
+            @Parameter(description = "The unique ID of the request", required = true) @PathVariable
+                    Long requestId,
+            @AuthenticationPrincipal User user) {
+        requestService.cancelRequest(requestId, user.getId());
+        return ResponseEntity.ok(
+                createSuccessResponse(new MessageResponse("Request canceled successfully!")));
+    }
+
+    @Operation(
             summary = "Get trip by request ID",
             description = "Retrieves a trip associated with a specific request ID")
     @ApiResponses(

--- a/src/main/java/com/yaquodorg/yaquod/controller/TripController.java
+++ b/src/main/java/com/yaquodorg/yaquod/controller/TripController.java
@@ -93,7 +93,7 @@ public class TripController {
 
     @Operation(
             summary = "Cancel Request",
-            description = "Cancels the current request and order vehicle to stop ETA calculations")
+            description = "Cancels the current request and orders vehicle to stop ETA calculations")
     @ApiResponses(
             value = {
                 @io.swagger.v3.oas.annotations.responses.ApiResponse(

--- a/src/main/java/com/yaquodorg/yaquod/dtos/TripCancelDto.java
+++ b/src/main/java/com/yaquodorg/yaquod/dtos/TripCancelDto.java
@@ -1,0 +1,19 @@
+package com.yaquodorg.yaquod.dtos;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class TripCancelDto {
+    // @ValidVIN
+    private String vinNumber;
+
+    @NotNull(message = "Request ID cannot be null")
+    private Long requestId;
+}

--- a/src/main/java/com/yaquodorg/yaquod/entity/RequestStatus.java
+++ b/src/main/java/com/yaquodorg/yaquod/entity/RequestStatus.java
@@ -2,6 +2,7 @@ package com.yaquodorg.yaquod.entity;
 
 public enum RequestStatus {
     PENDING,
+    CANCELED,
     COMPLETED,
     TIMEOUT,
     FAILED,

--- a/src/main/java/com/yaquodorg/yaquod/service/mqtt/MqttService.java
+++ b/src/main/java/com/yaquodorg/yaquod/service/mqtt/MqttService.java
@@ -32,6 +32,7 @@ public class MqttService {
             "topic/vehicle/update/status/order";
     private static final String TOPIC_VEHICLE_UPDATE_STATUS = "topic/vehicle/update/status";
     private static final String TOPIC_TRIP_INIT = "topic/trip/init";
+    private static final String TOPIC_TRIP_CANCEL = "topic/trip/cancel";
     private static final String TOPIC_TRIP_ETA = "topic/trip/eta";
     private static final String TOPIC_TRIP_MOVE = "topic/trip/move";
     private static final String TOPIC_TRIP_ARRIVE = "topic/trip/arrive";
@@ -87,6 +88,9 @@ public class MqttService {
                 break;
             case TOPIC_TRIP_INIT:
                 log.info("Sent trip init order successfully!");
+                break;
+            case TOPIC_TRIP_CANCEL:
+                log.info("Sent trip cancel order successfully!");
                 break;
             case TOPIC_TRIP_MOVE:
                 log.info("Sent trip move order successfully!");
@@ -268,6 +272,11 @@ public class MqttService {
         publish(TOPIC_TRIP_INIT, event);
         redisService.setValueWithTTL(
                 ETA_TIMEOUT_PREFIX + event.getRequestId(), "pending", ETA_TIMEOUT_SECONDS);
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleTripCanceled(TripCancelDto event) {
+        publish(TOPIC_TRIP_CANCEL, event);
     }
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)

--- a/src/main/java/com/yaquodorg/yaquod/service/request/RequestService.java
+++ b/src/main/java/com/yaquodorg/yaquod/service/request/RequestService.java
@@ -24,6 +24,8 @@ public interface RequestService {
 
     void deleteRequest(Long requestId);
 
+    void cancelRequest(Long id, Long userId);
+
     void declineRequestById(Long id, Long userId);
 
     Request acceptRequestById(Long id, Long userId);

--- a/src/main/java/com/yaquodorg/yaquod/service/request/RequestServiceImpl.java
+++ b/src/main/java/com/yaquodorg/yaquod/service/request/RequestServiceImpl.java
@@ -165,7 +165,8 @@ public class RequestServiceImpl implements RequestService {
     public void cancelRequest(Long id, Long userId) {
         log.info("Attempting to cancel request id: {} by user id: {}", id, userId);
         Request request = getRequest(id);
-        if (!request.getUser().getId().equals(userId)) {
+        User actor = userService.getUserById(userId);
+        if (actor.getRole() != Role.ADMIN && !request.getUser().getId().equals(userId)) {
             log.warn("Unauthorized attempt to cancel request id: {} by user id: {}", id, userId);
             throw new AccessDeniedException("Unauthorized to cancel this request");
         }

--- a/src/main/java/com/yaquodorg/yaquod/service/request/RequestServiceImpl.java
+++ b/src/main/java/com/yaquodorg/yaquod/service/request/RequestServiceImpl.java
@@ -1,6 +1,7 @@
 package com.yaquodorg.yaquod.service.request;
 
 import com.yaquodorg.yaquod.dtos.MoveVehicleDto;
+import com.yaquodorg.yaquod.dtos.TripCancelDto;
 import com.yaquodorg.yaquod.entity.*;
 import com.yaquodorg.yaquod.exception.ResourceNotFoundException;
 import com.yaquodorg.yaquod.repository.RequestRepository;
@@ -37,6 +38,9 @@ public class RequestServiceImpl implements RequestService {
     private final TripService tripService;
     private final VehicleService vehicleService;
     private final RedisService redisService;
+
+    @Value("${app.eta.timeout-prefix}")
+    private String ETA_TIMEOUT_PREFIX;
 
     @Value("${app.request.timeout-prefix}")
     private String REQUEST_TIMEOUT_PREFIX;
@@ -158,6 +162,70 @@ public class RequestServiceImpl implements RequestService {
 
     @Override
     @Transactional
+    public void cancelRequest(Long id, Long userId) {
+        log.info("Attempting to cancel request id: {} by user id: {}", id, userId);
+        Request request = getRequest(id);
+        if (!request.getUser().getId().equals(userId)) {
+            log.warn("Unauthorized attempt to cancel request id: {} by user id: {}", id, userId);
+            throw new AccessDeniedException("Unauthorized to cancel this request");
+        }
+
+        Trip trip = request.getTrip();
+        if (trip == null) {
+            log.error("No trip associated with request id: {}", id);
+            throw new IllegalStateException("No trip associated with request " + id);
+        }
+        long tripId = trip.getId();
+
+        Vehicle vehicle = trip.getVehicle();
+        if (vehicle == null) {
+            log.error("No vehicle associated with trip of request id: {}", id);
+            throw new IllegalStateException("No vehicle associated with trip of request " + id);
+        }
+        String vinNumber = vehicle.getVinNumber();
+
+        if (request.getStatus() != RequestStatus.PENDING) {
+            log.warn(
+                    "Request id: {} is not in PENDING state, current status: {}",
+                    id,
+                    request.getStatus());
+            throw new IllegalStateException("Request is not in PENDING state");
+        }
+        if (trip.getStatus() != TripStatus.INITIATED) {
+            log.warn(
+                    "Trip id: {} is not in INITIATED state, current status: {}",
+                    tripId,
+                    trip.getStatus());
+            throw new IllegalStateException("Trip is not in INITIATED state");
+        }
+        if (vehicle.getStatus() != VehicleStatus.PROCESSING) {
+            log.warn(
+                    "Vehicle VIN: {} is not in PROCESSING state, current status: {}",
+                    vinNumber,
+                    vehicle.getStatus());
+            throw new IllegalStateException("Vehicle is not in PROCESSING state");
+        }
+
+        redisService.delete(ETA_TIMEOUT_PREFIX + id);
+
+        TripCancelDto tripCancelDto =
+                TripCancelDto.builder().vinNumber(vinNumber).requestId(id).build();
+
+        eventPublisher.publishEvent(tripCancelDto);
+        log.info("Published TripCancelDto event for request id: {}", id);
+
+        updateRequestStatus(id, RequestStatus.CANCELED);
+        log.info("Request with id {} has changed to CANCELED.", id);
+
+        tripService.updateTripStatus(tripId, TripStatus.CANCELLED_BY_PASSENGER);
+        log.info("Trip with id {} has changed to CANCELLED_BY_PASSENGER", tripId);
+
+        vehicleService.updateVehicleStatus(vinNumber, VehicleStatus.IDLE);
+        log.info("Vehicle with vinNumber {} has been changed to IDLE", vinNumber);
+    }
+
+    @Override
+    @Transactional
     public void declineRequestById(Long id, Long userId) {
         log.info("Attempting to decline request id: {} by user id: {}", id, userId);
         Request request = getRequest(id);
@@ -201,7 +269,9 @@ public class RequestServiceImpl implements RequestService {
                     vehicle.getStatus());
             throw new IllegalStateException("Vehicle is not in ON_HOLD state");
         }
+
         redisService.delete(REQUEST_TIMEOUT_PREFIX + id);
+
         updateRequestStatus(id, RequestStatus.DECLINED);
         log.info("Request with id {} has changed to DECLINED.", id);
 


### PR DESCRIPTION
This pull request introduces a new feature allowing users to cancel a trip request and ensures that the cancellation is properly handled across the system, including updating statuses, publishing cancellation events, and cleaning up related resources. The implementation includes API, service, DTO, and MQTT integration changes.

**API and Business Logic Enhancements:**

* Added a new endpoint `DELETE /request/{requestId}` in `TripController` to allow authorized users (clients and admins) to cancel a request, with appropriate API documentation and security checks.
* Implemented the `cancelRequest` method in `RequestService` and its logic in `RequestServiceImpl`, which:
  * Validates user authorization and request/trip/vehicle states,
  * Updates the `Request`, `Trip`, and `Vehicle` statuses accordingly,
  * Removes ETA timeout entries from Redis,
  * Publishes a `TripCancelDto` event for further processing. [[1]](diffhunk://#diff-9baba5da75c54405b553539cf78e5cf42f7a8f1bb6c7a86b877bcac932ad6b69R27-R28) [[2]](diffhunk://#diff-ec3c23c8d2ba4c4dcafad37b15737ef62caac11ee1eb35d0b648a043b49d1971R163-R226)

**Domain Model and DTO Updates:**

* Introduced a new `TripCancelDto` DTO to encapsulate data for trip cancellation events.
* Added a new `CANCELED` status to the `RequestStatus` enum to represent canceled requests.

**MQTT Integration:**

* Added a new MQTT topic `topic/trip/cancel` and corresponding handling in `MqttService` to process trip cancellation events, including publishing `TripCancelDto` events and logging successful operations. [[1]](diffhunk://#diff-9dfa7a4a2f4fb823937f45281a6812ce935bb7157fa7b0d5c06a2f5bbd5a3f7eR35) [[2]](diffhunk://#diff-9dfa7a4a2f4fb823937f45281a6812ce935bb7157fa7b0d5c06a2f5bbd5a3f7eR92-R94) [[3]](diffhunk://#diff-9dfa7a4a2f4fb823937f45281a6812ce935bb7157fa7b0d5c06a2f5bbd5a3f7eR277-R281)

**Configuration and Dependency Enhancements:**

* Added `ETA_TIMEOUT_PREFIX` as a configurable property in `RequestServiceImpl` to manage Redis keys for ETA timeouts.

These changes collectively enable robust trip cancellation functionality, ensuring all related system components are updated and notified accordingly.