### PR TITLE
Implement Redis Idempotency Checks for MIT Payment Logic.

### DIFF
--- a/src/main/java/com/yaquodorg/yaquod/repository/PaymentRepository.java
+++ b/src/main/java/com/yaquodorg/yaquod/repository/PaymentRepository.java
@@ -8,4 +8,6 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface PaymentRepository extends JpaRepository<Payment, Long> {
     Optional<Payment> findByPaymobOrderId(String orderId);
+
+    Optional<Payment> findByTripId(Long tripId);
 }

--- a/src/main/java/com/yaquodorg/yaquod/service/payment/PaymentServiceImpl.java
+++ b/src/main/java/com/yaquodorg/yaquod/service/payment/PaymentServiceImpl.java
@@ -11,9 +11,11 @@ import com.yaquodorg.yaquod.entity.PaymentStatus;
 import com.yaquodorg.yaquod.entity.SavedCard;
 import com.yaquodorg.yaquod.entity.Trip;
 import com.yaquodorg.yaquod.entity.User;
+import com.yaquodorg.yaquod.exception.DuplicateKeyException;
 import com.yaquodorg.yaquod.exception.ResourceNotFoundException;
 import com.yaquodorg.yaquod.repository.PaymentRepository;
 import com.yaquodorg.yaquod.repository.SavedCardRepository;
+import com.yaquodorg.yaquod.service.redis.RedisService;
 import com.yaquodorg.yaquod.service.trip.TripService;
 import com.yaquodorg.yaquod.service.user.UserService;
 import java.math.BigDecimal;
@@ -21,6 +23,7 @@ import java.math.RoundingMode;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -40,6 +43,7 @@ public class PaymentServiceImpl implements PaymentService {
 
     private final UserService userService;
     private final TripService tripService;
+    private final RedisService redisService;
 
     private final SavedCardRepository savedCardRepository;
     private final PaymentRepository paymentRepository;
@@ -67,6 +71,9 @@ public class PaymentServiceImpl implements PaymentService {
 
     @Value("${payment.paymob.redirection-url}")
     private String redirectionUrl;
+
+    @Value("${app.payment.idempotency-prefix}")
+    private String IDEMPOTENCY_PREFIX;
 
     private static final String UNIFIED_CHECKOUT_URL = "https://accept.paymob.com/unifiedcheckout/";
 
@@ -283,6 +290,15 @@ public class PaymentServiceImpl implements PaymentService {
             User user, BigDecimal amountInEgp, Long savedCardId, Long requestId) {
         log.info("MIT direct charge for user: {}, amount: {} EGP", user.getId(), amountInEgp);
 
+        // TODO: Other payment ways and functions do not have idempotency checks yet.
+        String idempotencyKey = redisService.getValue(IDEMPOTENCY_PREFIX + requestId);
+
+        if (idempotencyKey != null) {
+            log.warn("Duplicate payment request for the same trip requestId: {}", requestId);
+            throw new DuplicateKeyException(
+                    "Duplicate payment request for the same trip requestId: " + requestId);
+        }
+
         SavedCard savedCard;
         if (savedCardId != null) {
             savedCard = savedCardRepository.findById(savedCardId).orElse(null);
@@ -307,6 +323,24 @@ public class PaymentServiceImpl implements PaymentService {
         if (!trip.getUser().getId().equals(user.getId())) {
             throw new AccessDeniedException("Cannot pay for another user's trip.");
         }
+
+        Optional<Payment> payment = paymentRepository.findByTripId(trip.getId());
+        if (payment.isPresent()) {
+            PaymentStatus status = payment.get().getStatus();
+
+            log.warn(
+                    "Payment for the trip with requestId: {} has already been processed with"
+                            + " status: {}.",
+                    requestId,
+                    status);
+            throw new DuplicateKeyException(
+                    "Payment for the trip with requestId: "
+                            + requestId
+                            + " has already been processed with status: "
+                            + status);
+        }
+
+        redisService.setValue(IDEMPOTENCY_PREFIX + requestId, "PENDING");
 
         Map<String, Object> intentionRequest =
                 buildMitIntentionRequest(user, savedCard, amountInCents);
@@ -338,8 +372,12 @@ public class PaymentServiceImpl implements PaymentService {
         log.info("Calling Paymob Pay API: {}", payUrl);
 
         String payResponse = restTemplate.postForObject(payUrl, payHttpRequest, String.class);
+        ChargeSavedCardDirectResponse response =
+                parseMitPayResponse(payResponse, orderId, user, savedCard, trip, amountInCents);
 
-        return parseMitPayResponse(payResponse, orderId, user, savedCard, trip, amountInCents);
+        redisService.delete(IDEMPOTENCY_PREFIX + requestId);
+
+        return response;
     }
 
     private Map<String, Object> buildMitIntentionRequest(

--- a/src/main/java/com/yaquodorg/yaquod/service/payment/PaymentServiceImpl.java
+++ b/src/main/java/com/yaquodorg/yaquod/service/payment/PaymentServiceImpl.java
@@ -34,6 +34,8 @@ import org.springframework.http.MediaType;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 import org.springframework.web.client.RestTemplate;
 
 @Service
@@ -289,15 +291,7 @@ public class PaymentServiceImpl implements PaymentService {
     public ChargeSavedCardDirectResponse chargeSavedCardDirectly(
             User user, BigDecimal amountInEgp, Long savedCardId, Long requestId) {
         log.info("MIT direct charge for user: {}, amount: {} EGP", user.getId(), amountInEgp);
-
         // TODO: Other payment ways and functions do not have idempotency checks yet.
-        String idempotencyKey = redisService.getValue(IDEMPOTENCY_PREFIX + requestId);
-
-        if (idempotencyKey != null) {
-            log.warn("Duplicate payment request for the same trip requestId: {}", requestId);
-            throw new DuplicateKeyException(
-                    "Duplicate payment request for the same trip requestId: " + requestId);
-        }
 
         SavedCard savedCard;
         if (savedCardId != null) {
@@ -375,7 +369,13 @@ public class PaymentServiceImpl implements PaymentService {
         ChargeSavedCardDirectResponse response =
                 parseMitPayResponse(payResponse, orderId, user, savedCard, trip, amountInCents);
 
-        redisService.delete(IDEMPOTENCY_PREFIX + requestId);
+        TransactionSynchronizationManager.registerSynchronization(
+                new TransactionSynchronization() {
+                    @Override
+                    public void afterCommit() {
+                        redisService.delete(IDEMPOTENCY_PREFIX + requestId);
+                    }
+                });
 
         return response;
     }

--- a/src/main/resources/application-docker.yml
+++ b/src/main/resources/application-docker.yml
@@ -122,3 +122,6 @@ app:
   eta:
     timeout-prefix: "eta:timeout:"
     timeout-seconds: 150 # seconds before the estimated time of arrival (ETA) to trigger a timeout event
+  payment:
+    idempotency-prefix: "payment:idempotency:"
+    timeout-seconds: 180

--- a/src/main/resources/application-docker.yml
+++ b/src/main/resources/application-docker.yml
@@ -124,4 +124,3 @@ app:
     timeout-seconds: 150 # seconds before the estimated time of arrival (ETA) to trigger a timeout event
   payment:
     idempotency-prefix: "payment:idempotency:"
-    timeout-seconds: 180

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -110,4 +110,3 @@ app:
     timeout-seconds: 150 # seconds before the estimated time of arrival (ETA) to trigger a timeout event
   payment:
     idempotency-prefix: "payment:idempotency:"
-    timeout-seconds: 180

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -108,3 +108,6 @@ app:
   eta:
     timeout-prefix: "eta:timeout:"
     timeout-seconds: 150 # seconds before the estimated time of arrival (ETA) to trigger a timeout event
+  payment:
+    idempotency-prefix: "payment:idempotency:"
+    timeout-seconds: 180


### PR DESCRIPTION
This pull request introduces idempotency checks to the saved card direct payment flow, ensuring that duplicate payment attempts for the same trip are prevented. It also adds related configuration and refactors the `PaymentServiceImpl` to support these changes.

**Idempotency and duplicate payment handling:**

* Added a check in `PaymentServiceImpl.chargeSavedCardDirectly` to prevent duplicate payments for the same trip by querying `PaymentRepository.findByTripId` and throwing a `DuplicateKeyException` if a payment already exists. [[1]](diffhunk://#diff-87807b1d6764929bfb3834bf6f3c7651e183a958fb3fe87bdbf6b8750c69977bR321-R338) [[2]](diffhunk://#diff-96e1baf74915b4630848a3d3d4c2618e087a11924f3755a02e3d9936f4f7d51bR11-R12)
* Introduced Redis-based idempotency tracking: a pending payment status is set before processing, and the key is deleted after successful transaction commit, using a configurable prefix. [[1]](diffhunk://#diff-87807b1d6764929bfb3834bf6f3c7651e183a958fb3fe87bdbf6b8750c69977bR369-R380) [[2]](diffhunk://#diff-87807b1d6764929bfb3834bf6f3c7651e183a958fb3fe87bdbf6b8750c69977bR77-R79) [[3]](diffhunk://#diff-87807b1d6764929bfb3834bf6f3c7651e183a958fb3fe87bdbf6b8750c69977bR48) [[4]](diffhunk://#diff-8c2ffb0d9d8127baf51f1b7f9042c3cda875be10d0451b7e29a744ad68cbd550R125-R126) [[5]](diffhunk://#diff-ddebd657255d1b279b4a97038254d040d5d1d6e84a99627919463066b9a4a89cR111-R112)

**Supporting changes:**

* Added `findByTripId` method to `PaymentRepository` to enable trip-based payment lookups.
* Added dependency injection for `RedisService` and configuration for the idempotency prefix in `PaymentServiceImpl`. [[1]](diffhunk://#diff-87807b1d6764929bfb3834bf6f3c7651e183a958fb3fe87bdbf6b8750c69977bR48) [[2]](diffhunk://#diff-87807b1d6764929bfb3834bf6f3c7651e183a958fb3fe87bdbf6b8750c69977bR77-R79)
* Updated imports and added a TODO comment noting that other payment flows do not yet have idempotency checks. [[1]](diffhunk://#diff-87807b1d6764929bfb3834bf6f3c7651e183a958fb3fe87bdbf6b8750c69977bR14-R26) [[2]](diffhunk://#diff-87807b1d6764929bfb3834bf6f3c7651e183a958fb3fe87bdbf6b8750c69977bR294)