### PR TITLE
Implement Vehicle Location Streaming with MQTT and SSE.

### DIFF
--- a/src/main/java/com/yaquodorg/yaquod/config/SecurityConfig.java
+++ b/src/main/java/com/yaquodorg/yaquod/config/SecurityConfig.java
@@ -7,6 +7,7 @@ import com.yaquodorg.yaquod.filter.CustomAccessDeniedFilter;
 import com.yaquodorg.yaquod.filter.JwtAuthenticationFilter;
 import com.yaquodorg.yaquod.security.OAuth2LoginSuccessHandler;
 import com.yaquodorg.yaquod.security.VehicleAuthenticationProvider;
+import jakarta.servlet.DispatcherType;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
@@ -56,7 +57,9 @@ public class SecurityConfig {
                 .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .authorizeHttpRequests(
                         req ->
-                                req.requestMatchers("/api/auth/**")
+                                req.dispatcherTypeMatchers(DispatcherType.ASYNC)
+                                        .permitAll()
+                                        .requestMatchers("/api/auth/**")
                                         .permitAll()
                                         .requestMatchers("/api/payments/webhook")
                                         .permitAll()

--- a/src/main/java/com/yaquodorg/yaquod/controller/TripController.java
+++ b/src/main/java/com/yaquodorg/yaquod/controller/TripController.java
@@ -27,6 +27,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 @RestController
 @RequestMapping("/api/trips")
@@ -321,6 +322,27 @@ public class TripController {
             @AuthenticationPrincipal User user) {
         Request request = requestService.acceptRequestById(requestId, user.getId());
         return ResponseEntity.ok(createSuccessResponse(request));
+    }
+
+    @Operation(
+            summary = "Track vehicle location streaming",
+            description = "SSE endpoint to keep receiving the vehicle location update stream.")
+    @ApiResponses(
+            value = {
+                @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                        responseCode = "200",
+                        description = "Ok"),
+                @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                        responseCode = "403",
+                        description = "Access denied"),
+                @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                        responseCode = "409",
+                        description = "Invalid request state for acceptance")
+            })
+    @PreAuthorize("hasAnyRole('CLIENT', 'ADMIN')")
+    @GetMapping("/{tripId}/location/stream")
+    public SseEmitter streamLocation(@PathVariable Long tripId) {
+        return tripService.subscribeToLocationStream(tripId);
     }
 
     @Operation(summary = "Start a trip", description = "Moves vehicle and starts trip.")

--- a/src/main/java/com/yaquodorg/yaquod/dtos/VehicleStreamLocationDto.java
+++ b/src/main/java/com/yaquodorg/yaquod/dtos/VehicleStreamLocationDto.java
@@ -1,0 +1,23 @@
+package com.yaquodorg.yaquod.dtos;
+
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class VehicleStreamLocationDto {
+    // @ValidVIN
+    private String vinNumber;
+
+    private long tripId;
+
+    @DecimalMin("-180.0")
+    @DecimalMax("180.0")
+    private Double longitude;
+
+    @DecimalMin("-90.0")
+    @DecimalMax("90.0")
+    private Double latitude;
+}

--- a/src/main/java/com/yaquodorg/yaquod/service/mqtt/MqttService.java
+++ b/src/main/java/com/yaquodorg/yaquod/service/mqtt/MqttService.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.yaquodorg.yaquod.dtos.*;
 import com.yaquodorg.yaquod.entity.*;
+import com.yaquodorg.yaquod.exception.ResourceNotFoundException;
 import com.yaquodorg.yaquod.service.messaging.FirebaseMessagingService;
 import com.yaquodorg.yaquod.service.redis.RedisService;
 import com.yaquodorg.yaquod.service.request.RequestService;
@@ -37,6 +38,7 @@ public class MqttService {
     private static final String TOPIC_TRIP_MOVE = "topic/trip/move";
     private static final String TOPIC_TRIP_ARRIVE = "topic/trip/arrive";
     private static final String TOPIC_TRIP_STATUS = "topic/trip/status";
+    private static final String TOPIC_TRIP_STREAM_LOCATION = "topic/trip/stream_location";
 
     private final MqttGateway mqttGateway;
     private final ObjectMapper objectMapper;
@@ -79,6 +81,9 @@ public class MqttService {
                 break;
             case TOPIC_TRIP_STATUS:
                 handleVehicleUpdateTripStatus(payload);
+                break;
+            case TOPIC_TRIP_STREAM_LOCATION:
+                handleVehicleStreamLocation(payload);
                 break;
             case TOPIC_VEHICLE_UPDATE_LOCATION_ORDER:
                 log.info("Sent vehicle update location order successfully!");
@@ -247,6 +252,38 @@ public class MqttService {
 
         } catch (Exception e) {
             log.error("Failed to parse vehicle update status payload: {}", payload, e);
+        }
+    }
+
+    private void handleVehicleStreamLocation(String payload) {
+        try {
+            VehicleStreamLocationDto dto =
+                    objectMapper.readValue(payload, VehicleStreamLocationDto.class);
+            log.info(
+                    "Vehicle with vin: {} streamed location at long, lat: {}, {} for trip with id:"
+                            + " {}",
+                    dto.getVinNumber(),
+                    dto.getLongitude(),
+                    dto.getLatitude(),
+                    dto.getTripId());
+
+            Trip trip = tripService.getTripById(dto.getTripId());
+            if (trip == null) {
+                throw new ResourceNotFoundException(
+                        "Trip with id: " + dto.getTripId() + "  not found");
+            }
+
+            Vehicle vehicle = trip.getVehicle();
+            if (vehicle.getStatus() != VehicleStatus.ON_WAY) {
+                throw new RuntimeException(
+                        "Vehicle status was not ON_WAY and instead: " + vehicle.getStatus());
+            }
+
+            tripService.broadcastLocationStream(
+                    dto.getTripId(), dto.getLatitude(), dto.getLongitude());
+
+        } catch (Exception e) {
+            log.error("Failed to parse vehicle stream location payload: {}", payload, e);
         }
     }
 

--- a/src/main/java/com/yaquodorg/yaquod/service/mqtt/MqttService.java
+++ b/src/main/java/com/yaquodorg/yaquod/service/mqtt/MqttService.java
@@ -66,6 +66,8 @@ public class MqttService {
         String topic = (String) message.getHeaders().get(MqttHeaders.RECEIVED_TOPIC);
         String payload = message.getPayload().toString();
 
+        log.info("Received message from topic '{}': {}", topic, payload);
+
         switch (topic) {
             case TOPIC_VEHICLE_UPDATE_LOCATION:
                 handleVehicleUpdateLocation(payload);
@@ -107,8 +109,6 @@ public class MqttService {
                 log.warn("Unhandled topic: {}", topic);
                 break;
         }
-
-        log.info("Received message from topic '{}': {}", topic, payload);
     }
 
     private void handleVehicleUpdateLocation(String payload) {
@@ -213,6 +213,8 @@ public class MqttService {
                 tripService.updateTripStatus(dto.getTripId(), TripStatus.ARRIVED_AT_PICKUP);
                 vehicleService.updateVehicleStatus(
                         dto.getVinNumber(), VehicleStatus.WAITING_PASSENGER);
+
+                tripService.unsubscribeToLocationStream(dto.getTripId());
             } else if (isNearLocation(
                     dto.getLatitude(), dto.getLongitude(), destinationLat, destinationLong)) {
                 message = carInfo + " has arrived at your destination.";

--- a/src/main/java/com/yaquodorg/yaquod/service/trip/TripService.java
+++ b/src/main/java/com/yaquodorg/yaquod/service/trip/TripService.java
@@ -4,6 +4,7 @@ import com.yaquodorg.yaquod.entity.Request;
 import com.yaquodorg.yaquod.entity.Trip;
 import com.yaquodorg.yaquod.entity.TripStatus;
 import java.util.List;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 public interface TripService {
     void createTrip(
@@ -24,6 +25,10 @@ public interface TripService {
     void updateTripStatus(Long id, TripStatus tripStatus);
 
     void deleteTripById(Long id);
+
+    SseEmitter subscribeToLocationStream(Long tripId);
+
+    void broadcastLocationStream(Long tripId, double latitude, double longitude);
 
     void startTrip(Long requestId);
 

--- a/src/main/java/com/yaquodorg/yaquod/service/trip/TripService.java
+++ b/src/main/java/com/yaquodorg/yaquod/service/trip/TripService.java
@@ -28,6 +28,8 @@ public interface TripService {
 
     SseEmitter subscribeToLocationStream(Long tripId);
 
+    void unsubscribeToLocationStream(Long tripId);
+
     void broadcastLocationStream(Long tripId, double latitude, double longitude);
 
     void startTrip(Long requestId);

--- a/src/main/java/com/yaquodorg/yaquod/service/trip/TripServiceImpl.java
+++ b/src/main/java/com/yaquodorg/yaquod/service/trip/TripServiceImpl.java
@@ -9,9 +9,12 @@ import com.yaquodorg.yaquod.exception.ServiceUnavailableException;
 import com.yaquodorg.yaquod.repository.TripRepository;
 import com.yaquodorg.yaquod.service.user.UserService;
 import com.yaquodorg.yaquod.service.vehicle.VehicleService;
+import java.io.IOException;
 import java.sql.Timestamp;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.locationtech.jts.geom.Point;
@@ -19,6 +22,7 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 @Service
 @RequiredArgsConstructor
@@ -32,6 +36,8 @@ public class TripServiceImpl implements TripService {
     private final UserService userService;
 
     private final ApplicationEventPublisher eventPublisher;
+
+    private final Map<Long, SseEmitter> emitters = new ConcurrentHashMap<>();
 
     @Transactional
     @Override
@@ -183,6 +189,27 @@ public class TripServiceImpl implements TripService {
         List<Trip> trips = tripRepository.findByVehicleVinNumber(vehicle.getVinNumber());
         log.debug("Found {} trips for vehicle VIN: {}", trips.size(), vinNumber);
         return trips;
+    }
+
+    @Override
+    public SseEmitter subscribeToLocationStream(Long tripId) {
+        SseEmitter emitter = new SseEmitter(Long.MAX_VALUE);
+        emitters.put(tripId, emitter);
+        emitter.onCompletion(() -> emitters.remove(tripId));
+        emitter.onTimeout(() -> emitters.remove(tripId));
+        return emitter;
+    }
+
+    @Override
+    public void broadcastLocationStream(Long tripId, double latitude, double longitude) {
+        SseEmitter emitter = emitters.get(tripId);
+        if (emitter != null) {
+            try {
+                emitter.send(Map.of("lat", latitude, "lon", longitude));
+            } catch (IOException e) {
+                emitters.remove(tripId);
+            }
+        }
     }
 
     @Transactional

--- a/src/main/java/com/yaquodorg/yaquod/service/trip/TripServiceImpl.java
+++ b/src/main/java/com/yaquodorg/yaquod/service/trip/TripServiceImpl.java
@@ -193,6 +193,7 @@ public class TripServiceImpl implements TripService {
 
     @Override
     public SseEmitter subscribeToLocationStream(Long tripId) {
+        log.info("A user has subscribed to vehicle location stream assigned to trip: {}", tripId);
         SseEmitter emitter = new SseEmitter(Long.MAX_VALUE);
         emitters.put(tripId, emitter);
         emitter.onCompletion(() -> emitters.remove(tripId));
@@ -201,13 +202,26 @@ public class TripServiceImpl implements TripService {
     }
 
     @Override
+    public void unsubscribeToLocationStream(Long tripId) {
+        SseEmitter emitter = emitters.get(tripId);
+        if (emitter != null) {
+            emitter.complete();
+            emitters.remove(tripId);
+        }
+
+        log.info("A user has unsubscribed to vehicle location stream assigned to trip: {}", tripId);
+    }
+
+    @Override
     public void broadcastLocationStream(Long tripId, double latitude, double longitude) {
         SseEmitter emitter = emitters.get(tripId);
         if (emitter != null) {
             try {
                 emitter.send(Map.of("lat", latitude, "lon", longitude));
+                log.info("location streamed: {}, {} for trip: {} ", latitude, longitude, tripId);
             } catch (IOException e) {
                 emitters.remove(tripId);
+                log.error("Exception thrown while trying to stream location: {}", e);
             }
         }
     }

--- a/src/main/resources/application-docker.yml
+++ b/src/main/resources/application-docker.yml
@@ -75,6 +75,7 @@ mqtt:
     - topic/trip/eta
     - topic/trip/arrive
     - topic/trip/status
+    - topic/trip/stream_location
   qos: ${MQTT_QOS:1}
   connection-timeout: ${MQTT_CONNECTION_TIMEOUT:60}
   keep-alive-interval: ${MQTT_KEEP_ALIVE_INTERVAL:60}

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -67,6 +67,7 @@ mqtt:
     - topic/trip/eta
     - topic/trip/arrive
     - topic/trip/status
+    - topic/trip/stream_location
   qos: 1
   connection-timeout: 60
   keep-alive-interval: 60


### PR DESCRIPTION
This pull request introduces real-time vehicle location streaming for trips using Server-Sent Events (SSE) and MQTT integration. The main changes include a new DTO for streaming vehicle location, updates to the MQTT service to handle streaming messages, and new methods in the trip service to manage SSE emitters and broadcast location updates to clients.

**Vehicle Location Streaming Feature:**

* Added a new SSE endpoint (`/api/trips/{tripId}/location/stream`) in `TripController` to allow clients to subscribe to real-time vehicle location updates for a trip.
* Introduced `VehicleStreamLocationDto` to encapsulate vehicle location data sent via MQTT.
* Updated `MqttService` to handle `topic/trip/stream_location` messages, parse the payload, and trigger location broadcasts. [[1]](diffhunk://#diff-9dfa7a4a2f4fb823937f45281a6812ce935bb7157fa7b0d5c06a2f5bbd5a3f7eR41) [[2]](diffhunk://#diff-9dfa7a4a2f4fb823937f45281a6812ce935bb7157fa7b0d5c06a2f5bbd5a3f7eR85-R87) [[3]](diffhunk://#diff-9dfa7a4a2f4fb823937f45281a6812ce935bb7157fa7b0d5c06a2f5bbd5a3f7eR258-R289)
* Added methods in `TripService` and `TripServiceImpl` to manage SSE emitters (`subscribeToLocationStream`) and broadcast location updates to subscribed clients (`broadcastLocationStream`). [[1]](diffhunk://#diff-d040c24c5488260b900c1c05156d49dce15db9048e4e0323b60f19c77e7f09b3R29-R32) [[2]](diffhunk://#diff-3665726e3ac2373b4d53fc68aeb7afc9f5ca0b650ea1bce6dd5086fa38b2938fR194-R214)

**Configuration Updates:**

* Registered the new MQTT topic `topic/trip/stream_location` in both `application-docker.yml` and `application-test.yml` to ensure the service subscribes to location stream messages. [[1]](diffhunk://#diff-8c2ffb0d9d8127baf51f1b7f9042c3cda875be10d0451b7e29a744ad68cbd550R78) [[2]](diffhunk://#diff-ddebd657255d1b279b4a97038254d040d5d1d6e84a99627919463066b9a4a89cR70)